### PR TITLE
Update PowerShell execution handler to PowerShell3

### DIFF
--- a/run-stryker/task/task.json
+++ b/run-stryker/task/task.json
@@ -32,7 +32,7 @@
     }
   ],
   "execution": {
-    "PowerShell": {
+    "PowerShell3": {
       "target": "$(currentDirectory)\\run-stryker.ps1",
       "argumentFormat": "",
       "workingDirectory": "$(Agent.BuildDirectory)"


### PR DESCRIPTION
##[warning]Task 'run-stryker' (1.0.7) is using deprecated task execution handler. The task should use the supported task-lib: https://aka.ms/tasklib